### PR TITLE
Update the order of topics in readthedocs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,16 +8,9 @@ Welcome to the Universal Transfer Operator documentation!
 
 .. toctree::
    :maxdepth: 2
-   :caption: Getting Started With Universal Transfer Operator:
    :glob:
 
    getting-started/*
-
-.. toctree::
-   :maxdepth: 2
-   :caption: Universal Transfer Operator:
-   :glob:
-
    universal_transfer_operator/operator.rst
 
 .. toctree::

--- a/docs/universal_transfer_operator/operator.rst
+++ b/docs/universal_transfer_operator/operator.rst
@@ -1,12 +1,8 @@
 .. _universal_transfer_operator:
 
-========================================================================================================
-:py:mod:`universal_transfer_operator operator <universal_transfer_operator.universal_transfer_operator>`
-========================================================================================================
-
 When to use the ``universal_transfer_operator`` operator
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The Universal Transfer Operator allows data transfers between any supported source :ref:`dataset` and destination :ref:`dataset`. It offers a consistent agnostic interface, simplifying the users' experience, so they do not need to use specific providers or operators for transfers.
+The :py:mod:`universal_transfer_operator operator <universal_transfer_operator.universal_transfer_operator>` allows data transfers between any supported source :ref:`dataset` and destination :ref:`dataset`. It offers a consistent agnostic interface, simplifying the users' experience, so they do not need to use specific providers or operators for transfers.
 
 This ensures a consistent set of :py:mod:`Data Providers <universal_transfer_operator.data_providers>` that can read from and write to :ref:`dataset`. The Universal Transfer
 Operator can use the respective :py:mod:`Data Providers <universal_transfer_operator.data_providers>` to transfer between as a source and a destination. It also takes advantage of any existing fast and


### PR DESCRIPTION
# Description
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
<img width="679" alt="image (5)" src="https://user-images.githubusercontent.com/8670962/228011587-990ae669-8979-4c89-b00e-f4f31f90ebff.png">
In the above screenshot - remove the sentence “Getting Started With Universal Transfer Operator” sentence as we anyway have hyperlink for “Getting Started” below it
More on https://astronomer.slack.com/archives/C03868KGF2Q/p1679935004385479?thread_ts=1679929706.712479&cid=C03868KGF2Q
<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Reorder the docs topics
<img width="1071" alt="Screenshot 2023-03-27 at 10 41 01 PM" src="https://user-images.githubusercontent.com/8670962/228011902-7435a437-2e69-4b56-a679-43ba5431e789.png">


## Does this introduce a breaking change?
No

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
