### PR TITLE
Add `nox build` for release process

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -106,5 +106,4 @@ def build(session: nox.Session) -> None:
             "You can use `git clean -fxdi -- dist` command to do this."
         )
     dist.mkdir(exist_ok=True)
-
     session.run("python", "-m", "build", *session.posargs)

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,6 @@
 """Nox automation definitions."""
 
-
+import pathlib
 import nox
 
 nox.options.sessions = ["dev"]
@@ -90,3 +90,21 @@ def release(session: nox.Session) -> None:
     # TODO: Better artifact checking.
     session.run("twine", "check", *session.posargs)
     session.run("twine", "upload", *session.posargs)
+
+
+@nox.session()
+def build(session: nox.Session) -> None:
+    """Build release artifacts."""
+    session.install("build")
+
+    # TODO: Automate version bumping, Git tagging, and more?
+
+    dist = pathlib.Path("dist")
+    if dist.exists() and next(dist.iterdir(), None) is not None:
+        session.error(
+            "There are files in dist/. Remove them and try again. "
+            "You can use `git clean -fxdi -- dist` command to do this."
+        )
+    dist.mkdir(exist_ok=True)
+
+    session.run("python", "-m", "build", *session.posargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["flit_core ~=3.2"]
 build-backend = "flit_core.buildapi"
 
 [project]
-name = "universal-transfer-operator"
+name = "apache-airflow-provider-transfers"
 dynamic = ["version"]
 description = """Universal Transfer Operator transfers all the data that could be read from the source Dataset into
 the destination Dataset. From a DAG author standpoint, all transfers would be performed through the invocation of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,10 @@ build-backend = "flit_core.buildapi"
 [project]
 name = "apache-airflow-provider-transfers"
 dynamic = ["version"]
-description = """Universal Transfer Operator transfers all the data that could be read from the source Dataset into
-the destination Dataset. From a DAG author standpoint, all transfers would be performed through the invocation of
-only the Universal Transfer Operator."""
+description = """This project contains the Universal Transfer Operator which can transfer all the data
+that could be read from the source Dataset into the destination Dataset.
+From a DAG author standpoint, all transfers would be performed through the invocation of only the
+Universal Transfer Operator."""
 
 authors = [
     { name = "Astronomer", email = "humans@astronomer.io" },

--- a/src/universal_transfer_operator/__init__.py
+++ b/src/universal_transfer_operator/__init__.py
@@ -10,7 +10,7 @@ __version__ = "0.1.0dev1"
 def get_provider_info() -> dict:
     return {
         # Required.
-        "package-name": "universal-transfer-operator",
+        "package-name": "apache-airflow-provider-transfers",
         "name": "Universal Transfer Operator",
         "description": __doc__,
         "versions": [__version__],

--- a/src/universal_transfer_operator/__init__.py
+++ b/src/universal_transfer_operator/__init__.py
@@ -1,6 +1,6 @@
 """An Operator that allows transfers between different datasets."""
 
-__version__ = "0.0.1dev1"
+__version__ = "0.1.0dev1"
 
 
 # This is needed to allow Airflow to pick up specific metadata fields it needs


### PR DESCRIPTION
# Description
## What is the current behavior?
There is no functionality to build the release artifacts using nox



## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Add nox build per session
- Change the pyproject.toml to get the project name as apache-airflow-provider-transfers in PyPI
- Test upload to PyPI available at the link https://test.pypi.org/project/apache-airflow-provider-transfers/

## Does this introduce a breaking change?
No

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
