### PR TITLE
Fix `CONTRIBUTING.md` to have correct link

### DIFF
--- a/docs/development/CONTRIBUTING.md
+++ b/docs/development/CONTRIBUTING.md
@@ -29,8 +29,9 @@ Follow the steps described in [development](DEVELOPMENT.md).
 
 1. Update the local sources to address the issue you are working on.
 
-   * Create a local branch for your development. Make sure to use latest
-     [astronomer/astro-sdk/main](https://github.com/astronomer/astro-sdk) as base for the branch. This allows you to easily compare
+   * Create a local branch for your development. Make sure to use the latest
+     [astronomer/apache-airflow-provider-transfers/main](https://github.com/astronomer/apache-airflow-provider-transfers) 
+     as base for the branch. This allows you to easily compare
      changes, have several changes that you work on at the same time and many more.
 
    * Add necessary code and (unit) tests.


### PR DESCRIPTION
# Description
## What is the current behavior?
`CONTRIBUTING.md` is currently referencing the astro-sdk repo


<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Fix `CONTRIBUTING.md` to have correct repo reference link


## Does this introduce a breaking change?


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [X] Extended the README / documentation, if necessary
