### PR TITLE
Add append and replace load strategies with example DAG for Table

### DIFF
--- a/docs/universal_transfer_operator/operator.rst
+++ b/docs/universal_transfer_operator/operator.rst
@@ -101,7 +101,7 @@ Following are the load strategies supported for :ref:`table` transfers:
 If the table you trying to create already exists, you can specify whether you want to replace the table or append the new data by specifying either if_exists='append' or if_exists='replace'.
 
 1. ``if_exists="replace"``
-    By default if ``transfer_params`` if not passed as an argument to :py:mod:`universal_transfer_operator operator <universal_transfer_operator.universal_transfer_operator>`, it sets if_exists='replace' by default.
+    By default if ``transfer_params`` is not passed as an argument to :py:mod:`universal_transfer_operator operator <universal_transfer_operator.universal_transfer_operator>`, it sets if_exists='replace' by default.
 
     .. literalinclude:: ../../example_dags/example_append_and_replace_strategies.py
        :language: python

--- a/docs/universal_transfer_operator/operator.rst
+++ b/docs/universal_transfer_operator/operator.rst
@@ -83,3 +83,38 @@ Comparison with traditional transfer Operator
            :language: python
            :start-after: [START howto_transfer_data_from_s3_to_snowflake_using_S3ToSnowflakeOperator]
            :end-before: [END howto_transfer_data_from_s3_to_snowflake_using_S3ToSnowflakeOperator]
+
+
+.. _load_strategies:
+
+Load Strategies
+~~~~~~~~~~~~~~~
+
+Following are the load strategies supported for :ref:`table` transfers:
+
+.. literalinclude:: ../../src/universal_transfer_operator/constants.py
+   :language: python
+   :start-after: [START LoadExistStrategy]
+   :end-before: [END LoadExistStrategy]
+
+
+If the table you trying to create already exists, you can specify whether you want to replace the table or append the new data by specifying either if_exists='append' or if_exists='replace'.
+
+1. ``if_exists="replace"``
+    By default if ``transfer_params`` if not passed as an argument to :py:mod:`universal_transfer_operator operator <universal_transfer_operator.universal_transfer_operator>`, it sets if_exists='replace' by default.
+
+    .. literalinclude:: ../../example_dags/example_append_and_replace_strategies.py
+       :language: python
+       :start-after: [START howto_transfer_data_from_s3_to_snowflake_using_replace]
+       :end-before: [END howto_transfer_data_from_s3_to_snowflake_using_replace]
+
+    .. note::
+        If you use if_exists='replace', the existing table will be dropped and the schema of the new data will be used.
+
+2. ``if_exists="append"``
+    User can set ``if_exists="append"`` passing an argument ``transfer_params=TransferIntegrationOptions(if_exists="append")`` to :py:mod:`universal_transfer_operator operator <universal_transfer_operator.universal_transfer_operator>` as the example below:
+
+    .. literalinclude:: ../../example_dags/example_append_and_replace_strategies.py
+       :language: python
+       :start-after: [START howto_transfer_data_from_s3_to_snowflake_using_append]
+       :end-before: [END howto_transfer_data_from_s3_to_snowflake_using_append]

--- a/docs/universal_transfer_operator/operator.rst
+++ b/docs/universal_transfer_operator/operator.rst
@@ -90,7 +90,7 @@ Comparison with traditional transfer Operator
 Load Strategies
 ~~~~~~~~~~~~~~~
 
-Following are the load strategies supported for :ref:`table` transfers:
+Following are the load strategies supported when :ref:`table` is the destination dataset:
 
 .. literalinclude:: ../../src/universal_transfer_operator/constants.py
    :language: python

--- a/docs/universal_transfer_operator/operator.rst
+++ b/docs/universal_transfer_operator/operator.rst
@@ -112,7 +112,7 @@ If the table you trying to create already exists, you can specify whether you wa
         If you use if_exists='replace', existing table will be dropped and the schema of the new data will be used.
 
 2. ``if_exists="append"``
-    User can set ``if_exists="append"`` passing an argument ``transfer_params=TransferIntegrationOptions(if_exists="append")`` to :py:mod:`universal_transfer_operator operator <universal_transfer_operator.universal_transfer_operator>` as the example below:
+    User can set ``if_exists="append"`` by passing an argument ``transfer_params=TransferIntegrationOptions(if_exists="append")`` to :py:mod:`universal_transfer_operator operator <universal_transfer_operator.universal_transfer_operator>` as the example below:
 
     .. literalinclude:: ../../example_dags/example_append_and_replace_strategies.py
        :language: python

--- a/docs/universal_transfer_operator/operator.rst
+++ b/docs/universal_transfer_operator/operator.rst
@@ -105,8 +105,8 @@ If the table you trying to create already exists, you can specify whether you wa
 
     .. literalinclude:: ../../example_dags/example_append_and_replace_strategies.py
        :language: python
-       :start-after: [START howto_transfer_data_from_s3_to_snowflake_using_replace]
-       :end-before: [END howto_transfer_data_from_s3_to_snowflake_using_replace]
+       :start-after: [START howto_transfer_data_from_s3_to_sqlite_using_replace]
+       :end-before: [END howto_transfer_data_from_s3_to_sqlite_using_replace]
 
     .. note::
         If you use if_exists='replace', existing table will be dropped and the schema of the new data will be used.
@@ -116,5 +116,5 @@ If the table you trying to create already exists, you can specify whether you wa
 
     .. literalinclude:: ../../example_dags/example_append_and_replace_strategies.py
        :language: python
-       :start-after: [START howto_transfer_data_from_s3_to_snowflake_using_append]
-       :end-before: [END howto_transfer_data_from_s3_to_snowflake_using_append]
+       :start-after: [START howto_transfer_data_from_s3_to_sqlite_using_append]
+       :end-before: [END howto_transfer_data_from_s3_to_sqlite_using_append]

--- a/docs/universal_transfer_operator/operator.rst
+++ b/docs/universal_transfer_operator/operator.rst
@@ -109,7 +109,7 @@ If the table you trying to create already exists, you can specify whether you wa
        :end-before: [END howto_transfer_data_from_s3_to_snowflake_using_replace]
 
     .. note::
-        If you use if_exists='replace', the existing table will be dropped and the schema of the new data will be used.
+        If you use if_exists='replace', existing table will be dropped and the schema of the new data will be used.
 
 2. ``if_exists="append"``
     User can set ``if_exists="append"`` passing an argument ``transfer_params=TransferIntegrationOptions(if_exists="append")`` to :py:mod:`universal_transfer_operator operator <universal_transfer_operator.universal_transfer_operator>` as the example below:

--- a/example_dags/example_append_and_replace_strategies.py
+++ b/example_dags/example_append_and_replace_strategies.py
@@ -49,7 +49,7 @@ with DAG(
     uto_transfer_non_native_s3_to_snowflake_append = UniversalTransferOperator(
         task_id="uto_transfer_non_native_s3_to_snowflake_append",
         source_dataset=File(
-            path="s3://astro-sdk-test/uto/csv_files/home2.csv", conn_id="aws_default", filetype=FileType.CSV
+            path="s3://astro-sdk-test/uto/csv_files/homes2.csv", conn_id="aws_default", filetype=FileType.CSV
         ),
         destination_dataset=Table(name="uto_s3_table_to_snowflake_append", conn_id="snowflake_conn"),
         transfer_params=TransferIntegrationOptions(if_exists="append"),

--- a/example_dags/example_append_and_replace_strategies.py
+++ b/example_dags/example_append_and_replace_strategies.py
@@ -1,0 +1,69 @@
+import os
+from datetime import datetime
+
+from airflow import DAG
+from airflow.providers.snowflake.operators.snowflake import SnowflakeOperator
+
+from universal_transfer_operator.constants import FileType
+from universal_transfer_operator.datasets.file.base import File
+from universal_transfer_operator.datasets.table import Table
+from universal_transfer_operator.universal_transfer_operator import (
+    TransferIntegrationOptions,
+    UniversalTransferOperator,
+)
+
+s3_bucket = os.getenv("S3_BUCKET", "s3://astro-sdk-test")
+gcs_bucket = os.getenv("GCS_BUCKET", "gs://uto-test")
+transform_table = """
+    SELECT
+       *
+    FROM {{ params.table_name }}
+"""
+
+with DAG(
+    "example_snowflake_transfers_append_and_replace_strategies",
+    schedule_interval=None,
+    start_date=datetime(2022, 1, 1),
+    catchup=False,
+) as dag:
+    # [START howto_transfer_data_from_s3_to_snowflake_using_replace]
+    uto_transfer_non_native_s3_to_snowflake_replace = UniversalTransferOperator(
+        task_id="uto_transfer_non_native_s3_to_snowflake_replace",
+        source_dataset=File(
+            path="s3://astro-sdk-test/uto/csv_files/", conn_id="aws_default", filetype=FileType.CSV
+        ),
+        destination_dataset=Table(name="uto_s3_table_to_snowflake_replace", conn_id="snowflake_conn"),
+    )
+    # [END howto_transfer_data_from_s3_to_snowflake_using_replace]
+
+    # [START howto_run_sql_table_check_after_replace]
+    snowflake_sql_query_after_replace = SnowflakeOperator(
+        task_id="snowflake_sql_query_after_replace",
+        sql=transform_table,
+        params={"table_name": "uto_s3_table_to_snowflake_replace"},
+        snowflake_conn_id="snowflake_conn",
+    )
+    # [END howto_run_sql_table_check_after_replace]
+
+    # [START howto_transfer_data_from_s3_to_snowflake_using_append]
+    uto_transfer_non_native_s3_to_snowflake_append = UniversalTransferOperator(
+        task_id="uto_transfer_non_native_s3_to_snowflake_append",
+        source_dataset=File(
+            path="s3://astro-sdk-test/uto/csv_files/", conn_id="aws_default", filetype=FileType.CSV
+        ),
+        destination_dataset=Table(name="uto_s3_table_to_snowflake_append", conn_id="snowflake_conn"),
+        transfer_params=TransferIntegrationOptions(if_exists="append"),
+    )
+    # [END howto_transfer_data_from_s3_to_snowflake_using_append]
+
+    # [START howto_run_sql_table_check_after_append]
+    snowflake_sql_query_after_append = SnowflakeOperator(
+        task_id="snowflake_sql_query_after_append",
+        sql=transform_table,
+        params={"table_name": "uto_s3_table_to_snowflake_append"},
+        snowflake_conn_id="snowflake_conn",
+    )
+    # [END howto_run_sql_table_check_after_append]
+
+    uto_transfer_non_native_s3_to_snowflake_replace >> snowflake_sql_query_after_replace
+    uto_transfer_non_native_s3_to_snowflake_append >> snowflake_sql_query_after_append

--- a/example_dags/example_append_and_replace_strategies.py
+++ b/example_dags/example_append_and_replace_strategies.py
@@ -49,7 +49,7 @@ with DAG(
     uto_transfer_non_native_s3_to_snowflake_append = UniversalTransferOperator(
         task_id="uto_transfer_non_native_s3_to_snowflake_append",
         source_dataset=File(
-            path="s3://astro-sdk-test/uto/csv_files/", conn_id="aws_default", filetype=FileType.CSV
+            path="s3://astro-sdk-test/uto/csv_files/home2.csv", conn_id="aws_default", filetype=FileType.CSV
         ),
         destination_dataset=Table(name="uto_s3_table_to_snowflake_append", conn_id="snowflake_conn"),
         transfer_params=TransferIntegrationOptions(if_exists="append"),

--- a/example_dags/example_append_and_replace_strategies.py
+++ b/example_dags/example_append_and_replace_strategies.py
@@ -1,8 +1,8 @@
 import os
+import pathlib
 from datetime import datetime
 
 from airflow import DAG
-from airflow.providers.snowflake.operators.snowflake import SnowflakeOperator
 
 from universal_transfer_operator.constants import FileType
 from universal_transfer_operator.datasets.file.base import File
@@ -12,58 +12,30 @@ from universal_transfer_operator.universal_transfer_operator import (
     UniversalTransferOperator,
 )
 
+CWD = pathlib.Path(__file__).parent
+DATA_DIR = str(CWD) + "/../../data/"
 s3_bucket = os.getenv("S3_BUCKET", "s3://astro-sdk-test")
 gcs_bucket = os.getenv("GCS_BUCKET", "gs://uto-test")
-transform_table = """
-    SELECT
-       *
-    FROM {{ params.table_name }}
-"""
 
 with DAG(
-    "example_snowflake_transfers_append_and_replace_strategies",
+    "example_sqlite_transfers_append_and_replace_strategies",
     schedule_interval=None,
     start_date=datetime(2022, 1, 1),
     catchup=False,
 ) as dag:
-    # [START howto_transfer_data_from_s3_to_snowflake_using_replace]
-    uto_transfer_non_native_s3_to_snowflake_replace = UniversalTransferOperator(
-        task_id="uto_transfer_non_native_s3_to_snowflake_replace",
-        source_dataset=File(
-            path="s3://astro-sdk-test/uto/csv_files/", conn_id="aws_default", filetype=FileType.CSV
-        ),
-        destination_dataset=Table(name="uto_s3_table_to_snowflake_replace", conn_id="snowflake_conn"),
+    # [START howto_transfer_data_from_s3_to_sqlite_using_replace]
+    uto_transfer_non_native_s3_to_sqlite_replace = UniversalTransferOperator(
+        task_id="uto_transfer_non_native_s3_to_sqlite_replace",
+        source_dataset=File(path=f"{DATA_DIR}sample.csv", filetype=FileType.CSV),
+        destination_dataset=Table(name="uto_s3_table_to_sqlite_replace", conn_id="sqlite_default"),
     )
-    # [END howto_transfer_data_from_s3_to_snowflake_using_replace]
+    # [END howto_transfer_data_from_s3_to_sqlite_using_replace]
 
-    # [START howto_run_sql_table_check_after_replace]
-    snowflake_sql_query_after_replace = SnowflakeOperator(
-        task_id="snowflake_sql_query_after_replace",
-        sql=transform_table,
-        params={"table_name": "uto_s3_table_to_snowflake_replace"},
-        snowflake_conn_id="snowflake_conn",
-    )
-    # [END howto_run_sql_table_check_after_replace]
-
-    # [START howto_transfer_data_from_s3_to_snowflake_using_append]
-    uto_transfer_non_native_s3_to_snowflake_append = UniversalTransferOperator(
-        task_id="uto_transfer_non_native_s3_to_snowflake_append",
-        source_dataset=File(
-            path="s3://astro-sdk-test/uto/csv_files/homes2.csv", conn_id="aws_default", filetype=FileType.CSV
-        ),
-        destination_dataset=Table(name="uto_s3_table_to_snowflake_append", conn_id="snowflake_conn"),
+    # [START howto_transfer_data_from_s3_to_sqlite_using_append]
+    uto_transfer_non_native_s3_to_sqlite_append = UniversalTransferOperator(
+        task_id="uto_transfer_non_native_s3_to_sqlite_append",
+        source_dataset=File(path=f"{DATA_DIR}sample.csv", filetype=FileType.CSV),
+        destination_dataset=Table(name="uto_s3_table_to_sqlite_append", conn_id="snowflake_conn"),
         transfer_params=TransferIntegrationOptions(if_exists="append"),
     )
-    # [END howto_transfer_data_from_s3_to_snowflake_using_append]
-
-    # [START howto_run_sql_table_check_after_append]
-    snowflake_sql_query_after_append = SnowflakeOperator(
-        task_id="snowflake_sql_query_after_append",
-        sql=transform_table,
-        params={"table_name": "uto_s3_table_to_snowflake_append"},
-        snowflake_conn_id="snowflake_conn",
-    )
-    # [END howto_run_sql_table_check_after_append]
-
-    uto_transfer_non_native_s3_to_snowflake_replace >> snowflake_sql_query_after_replace
-    uto_transfer_non_native_s3_to_snowflake_append >> snowflake_sql_query_after_append
+    # [END howto_transfer_data_from_s3_to_sqlite_using_append]

--- a/example_dags/example_universal_transfer_operator.py
+++ b/example_dags/example_universal_transfer_operator.py
@@ -80,7 +80,7 @@ with DAG(
         source_dataset=File(
             path="s3://astro-sdk-test/example_uto/csv_files/", conn_id="aws_default", filetype=FileType.CSV
         ),
-        destination_dataset=Table(name="uto_s3_table_to_snowflake", conn_id="snowflake_conn"),
+        destination_dataset=Table(name="uto_s3_table_to_snowflake_table", conn_id="snowflake_conn"),
     )
     # [END transfer_non_native_s3_to_snowflake]
 

--- a/src/universal_transfer_operator/constants.py
+++ b/src/universal_transfer_operator/constants.py
@@ -82,7 +82,10 @@ SUPPORTED_FILE_LOCATIONS = [const.value for const in FileLocation]
 SUPPORTED_FILE_TYPES = [const.value for const in FileType]
 SUPPORTED_DATABASES = [const.value for const in Database]
 
+# [START LoadExistStrategy]
 LoadExistStrategy = Literal["replace", "append"]
+# [END LoadExistStrategy]
+
 DEFAULT_CHUNK_SIZE = 1000000
 ColumnCapitalization = Literal["upper", "lower", "original"]
 DEFAULT_SCHEMA = "tmp_transfers"

--- a/src/universal_transfer_operator/data_providers/database/base.py
+++ b/src/universal_transfer_operator/data_providers/database/base.py
@@ -194,13 +194,18 @@ class DatabaseDataProvider(DataProviders[Table]):
 
         :param source_ref: Stream of data to be loaded into output table or a pandas dataframe.
         """
+        if_exists = self.transfer_params.if_exists
         # `source_ref` can be a dataframe for all the filetypes we can create a dataframe for like -
         # CSV, JSON, NDJSON, and Parquet or SQL Tables. This gives us the option to perform various
         # functions on the data on the fly, like filtering or changing the file format altogether. For other
         # files whose content cannot be converted to dataframe like - zip or image, we get a DataStream object.
         if isinstance(source_ref, DataStream):
-            return self.load_file_to_table(input_file=source_ref.actual_file, output_table=self.dataset)
-        return self.load_dataframe_to_table(input_dataframe=source_ref, output_table=self.dataset)
+            return self.load_file_to_table(
+                input_file=source_ref.actual_file, output_table=self.dataset, if_exists=if_exists
+            )
+        return self.load_dataframe_to_table(
+            input_dataframe=source_ref, output_table=self.dataset, if_exists=if_exists
+        )
 
     @property
     def openlineage_dataset_namespace(self) -> str:

--- a/src/universal_transfer_operator/utils.py
+++ b/src/universal_transfer_operator/utils.py
@@ -12,7 +12,7 @@ from universal_transfer_operator.datasets.table import Table
 
 @attr.define
 class TransferParameters:
-    if_exists: LoadExistStrategy = "replace"
+    if_exists: LoadExistStrategy = attr.field(default="replace")
 
 
 def check_if_connection_exists(conn_id: str) -> bool:

--- a/src/universal_transfer_operator/utils.py
+++ b/src/universal_transfer_operator/utils.py
@@ -5,13 +5,14 @@ from typing import Any
 import attr
 from airflow.hooks.base import BaseHook
 
+from universal_transfer_operator.constants import LoadExistStrategy
 from universal_transfer_operator.datasets.file.base import File
 from universal_transfer_operator.datasets.table import Table
 
 
 @attr.define
 class TransferParameters:
-    if_exists: str = "replace"
+    if_exists: LoadExistStrategy = "replace"
 
 
 def check_if_connection_exists(conn_id: str) -> bool:
@@ -29,7 +30,7 @@ def check_if_connection_exists(conn_id: str) -> bool:
     return True
 
 
-def get_dataset_connection_type(dataset: Table | File) -> str:
+def get_dataset_connection_type(dataset: Table | File) -> Any:
     """
     Given dataset fetch the connection type based on airflow connection
     """

--- a/tests_integration/test_data_provider/test_databases/test_base.py
+++ b/tests_integration/test_data_provider/test_databases/test_base.py
@@ -261,3 +261,75 @@ def test_load_pandas_dataframe_to_table_with_append(dst_dataset_fixture):
     assert rows[1] == (2,)
 
     dst_dp.drop_table(dataset)
+
+
+@pytest.mark.parametrize(
+    "dst_dataset_fixture",
+    [
+        {"name": "SqliteDataProvider"},
+        {
+            "name": "SnowflakeDataProvider",
+        },
+        {
+            "name": "BigqueryDataProvider",
+        },
+    ],
+    indirect=True,
+    ids=lambda db: db["name"],
+)
+def test_write_to_table_with_replace(dst_dataset_fixture):
+    """Write to a SQL table with replace strategy"""
+    dst_dp, dataset = dst_dataset_fixture
+
+    pandas_dataframe = pd.DataFrame(data={"id": [1, 2]})
+    dst_dp.write(pandas_dataframe)
+
+    rows = dst_dp.fetch_all_rows(dataset)
+    assert len(rows) == 2
+    assert rows[0] == (1,)
+    assert rows[1] == (2,)
+
+    pandas_dataframe = pd.DataFrame(data={"id": [3, 4]})
+    dst_dp.write(pandas_dataframe)
+    rows = dst_dp.fetch_all_rows(dataset)
+    assert len(rows) == 2
+    assert rows[0] == (3,)
+    assert rows[1] == (4,)
+
+    dst_dp.drop_table(dataset)
+
+
+@pytest.mark.parametrize(
+    "dst_dataset_fixture",
+    [
+        {"name": "SqliteDataProvider"},
+        {
+            "name": "SnowflakeDataProvider",
+        },
+        {
+            "name": "BigqueryDataProvider",
+        },
+    ],
+    indirect=True,
+    ids=lambda db: db["name"],
+)
+def test_write_to_table_with_append(dst_dataset_fixture):
+    """Write to a SQL table with append strategy"""
+    dst_dp, dataset = dst_dataset_fixture
+
+    pandas_dataframe = pd.DataFrame(data={"id": [1, 2]})
+    dst_dp.write(pandas_dataframe)
+
+    rows = dst_dp.fetch_all_rows(dataset)
+    assert len(rows) == 2
+    assert rows[0] == (1,)
+    assert rows[1] == (2,)
+
+    dst_dp.if_exists = "append"
+    dst_dp.write(pandas_dataframe)
+    rows = dst_dp.fetch_all_rows(dataset)
+    assert len(rows) == 4
+    assert rows[0] == (1,)
+    assert rows[1] == (2,)
+
+    dst_dp.drop_table(dataset)

--- a/tests_integration/test_data_provider/test_databases/test_base.py
+++ b/tests_integration/test_data_provider/test_databases/test_base.py
@@ -1,3 +1,4 @@
+import io
 import os
 import pathlib
 from urllib.parse import urlparse, urlunparse
@@ -8,6 +9,7 @@ import smart_open
 from pyarrow.lib import ArrowInvalid
 from utils.test_utils import create_unique_str
 
+from universal_transfer_operator.data_providers.base import DataStream
 from universal_transfer_operator.datasets.file.base import File
 from universal_transfer_operator.datasets.table import Table
 
@@ -277,8 +279,8 @@ def test_load_pandas_dataframe_to_table_with_append(dst_dataset_fixture):
     indirect=True,
     ids=lambda db: db["name"],
 )
-def test_write_to_table_with_replace(dst_dataset_fixture):
-    """Write to a SQL table with replace strategy"""
+def test_write_dataframe_to_table_with_replace(dst_dataset_fixture):
+    """Write dataframe to a SQL table with replace strategy"""
     dst_dp, dataset = dst_dataset_fixture
 
     pandas_dataframe = pd.DataFrame(data={"id": [1, 2]})
@@ -313,8 +315,8 @@ def test_write_to_table_with_replace(dst_dataset_fixture):
     indirect=True,
     ids=lambda db: db["name"],
 )
-def test_write_to_table_with_append(dst_dataset_fixture):
-    """Write to a SQL table with append strategy"""
+def test_write_dataframe_to_table_with_append(dst_dataset_fixture):
+    """Write dataframe to a SQL table with append strategy"""
     dst_dp, dataset = dst_dataset_fixture
 
     pandas_dataframe = pd.DataFrame(data={"id": [1, 2]})
@@ -331,5 +333,104 @@ def test_write_to_table_with_append(dst_dataset_fixture):
     assert len(rows) == 4
     assert rows[0] == (1,)
     assert rows[1] == (2,)
+
+    dst_dp.drop_table(dataset)
+
+
+@pytest.mark.parametrize(
+    "dst_dataset_fixture",
+    [
+        {"name": "SqliteDataProvider"},
+        {
+            "name": "SnowflakeDataProvider",
+        },
+        {
+            "name": "BigqueryDataProvider",
+        },
+    ],
+    indirect=True,
+    ids=lambda db: db["name"],
+)
+def test_write_file_datastream_to_table_with_replace(dst_dataset_fixture):
+    """Write file datastream to a SQL table with replace strategy"""
+    dst_dp, dataset = dst_dataset_fixture
+
+    filepath = f"{str(CWD)}/../../data/sample.csv"
+    remote_obj_buffer = io.StringIO()
+    with smart_open.open(filepath, mode="r", transport_params=None) as stream:
+        remote_obj_buffer.write(stream.read())
+        remote_obj_buffer.seek(0)
+
+        data_stream = DataStream(
+            remote_obj_buffer=remote_obj_buffer,
+            actual_filename="sample.csv",
+            actual_file=File(path=f"{str(CWD)}/../../data/sample.csv"),
+        )
+
+        dst_dp.write(data_stream)
+
+        rows = dst_dp.fetch_all_rows(dataset)
+        assert len(rows) == 3
+        assert rows[0] == (1, "First")
+        assert rows[1] == (2, "Second")
+        assert rows[2] == (3, "Third with unicode पांचाल")
+
+        dst_dp.write(data_stream)
+
+        rows = dst_dp.fetch_all_rows(dataset)
+        assert len(rows) == 3
+        assert rows[0] == (1, "First")
+        assert rows[1] == (2, "Second")
+        assert rows[2] == (3, "Third with unicode पांचाल")
+
+    dst_dp.drop_table(dataset)
+
+
+@pytest.mark.parametrize(
+    "dst_dataset_fixture",
+    [
+        {"name": "SqliteDataProvider"},
+        {
+            "name": "SnowflakeDataProvider",
+        },
+        {
+            "name": "BigqueryDataProvider",
+        },
+    ],
+    indirect=True,
+    ids=lambda db: db["name"],
+)
+def test_write_file_datastream_to_table_with_append(dst_dataset_fixture):
+    """Write file datastream to a SQL table with append strategy"""
+    dst_dp, dataset = dst_dataset_fixture
+
+    filepath = f"{str(CWD)}/../../data/sample.csv"
+    remote_obj_buffer = io.StringIO()
+    with smart_open.open(filepath, mode="r", transport_params=None) as stream:
+        remote_obj_buffer.write(stream.read())
+        remote_obj_buffer.seek(0)
+
+        data_stream = DataStream(
+            remote_obj_buffer=remote_obj_buffer,
+            actual_filename="sample.csv",
+            actual_file=File(path=f"{str(CWD)}/../../data/sample.csv"),
+        )
+
+        dst_dp.write(data_stream)
+
+        rows = dst_dp.fetch_all_rows(dataset)
+        assert len(rows) == 3
+        assert rows[0] == (1, "First")
+        assert rows[1] == (2, "Second")
+        assert rows[2] == (3, "Third with unicode पांचाल")
+
+        dst_dp.if_exists = "append"
+        dst_dp.write(data_stream)
+
+        rows = dst_dp.fetch_all_rows(dataset)
+        assert len(rows) == 6
+        assert rows[3] == (1, "First")
+        assert rows[4] == (2, "Second")
+        assert rows[5] == (3, "Third with unicode पांचाल")
 
     dst_dp.drop_table(dataset)


### PR DESCRIPTION
# Description
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Although the logic for the replace and append is implemented this is not working because if_exists is not propagated from TransferParams here: https://github.com/astronomer/apache-airflow-provider-transfers/blob/main/src/universal_transfer_operator/data_providers/database/base.py#L202

<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->
closes: #47


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Add append and replace load strategies with example DAG for Table
- Add example DAGs
- Add docs
- Test is already there to test the behaviour


## Does this introduce a breaking change?
No

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
